### PR TITLE
 Added the ability to override the default feign client read...

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,6 +49,9 @@ eureka:
 feign:
   hystrix:
     enabled: true
+  client:
+    javaToR:
+      readTimeout: ${javaToRServiceReadTimeout:5000}
 
 hystrix:
   shareSecurityContext: true


### PR DESCRIPTION
... timeout specifically for the javaToR service since UV Hydro takes significantly longer to render than other reports.