### PR TITLE
Added a default Aquarius timeout.

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,7 @@ aquarius:
     password: ${aquariusServicePassword}
     retries:
       unauthorized: ${aquariusUnauthorizedRetries:3}
+    timeout: 30000
 
 sims:
   base:


### PR DESCRIPTION
This report was already on the latest framework snapshot.