### PR TITLE
Advancing maven stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mvn -B dependency:go-offline
 
 COPY .git /build
 COPY src /build/src
-ARG BUILD_COMMAND="mvn -B clean package"
+ARG BUILD_COMMAND="mvn -B clean verify"
 RUN ${BUILD_COMMAND}
 
 FROM usgswma/wma-spring-boot-base:8-jre-slim-0.0.4


### PR DESCRIPTION
Switching this to `verify` so that it runs integration tests, and publishes sonar reports.

Note that the `verify` phase implies `package` according to the default maven lifecycle.
https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#Lifecycle_Reference